### PR TITLE
Add widget test for portrait mode.

### DIFF
--- a/lib/src/flare.dart
+++ b/lib/src/flare.dart
@@ -33,12 +33,14 @@ class FlareGiffyDialog extends StatelessWidget {
     this.buttonRadius = 8.0,
   })  : assert(flarePath != null),
         assert(title != null),
+        assert(flareAnimation != null),
         super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Dialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(cornerRadius)),
+      shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(cornerRadius)),
       child: (MediaQuery.of(context).orientation == Orientation.portrait)
           ? FlarePortraitMode(
               cardBackgroundColor: cardBackgroundColor,
@@ -122,7 +124,9 @@ class FlarePortraitMode extends StatelessWidget {
                   elevation: 0.0,
                   margin: EdgeInsets.all(0.0),
                   shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.only(topRight: Radius.circular(cornerRadius), topLeft: Radius.circular(cornerRadius))),
+                      borderRadius: BorderRadius.only(
+                          topRight: Radius.circular(cornerRadius),
+                          topLeft: Radius.circular(cornerRadius))),
                   clipBehavior: Clip.antiAlias,
                   child: FlareActor(
                     flarePath,
@@ -145,12 +149,15 @@ class FlarePortraitMode extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.all(8.0),
             child: Row(
-              mainAxisAlignment: !onlyOkButton ? MainAxisAlignment.spaceEvenly : MainAxisAlignment.center,
+              mainAxisAlignment: !onlyOkButton
+                  ? MainAxisAlignment.spaceEvenly
+                  : MainAxisAlignment.center,
               children: <Widget>[
                 !onlyOkButton
                     ? RaisedButton(
                         color: buttonCancelColor ?? Colors.grey,
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(buttonRadius)),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(buttonRadius)),
                         onPressed: () => Navigator.of(context).pop(),
                         child: buttonCancelText ??
                             Text(
@@ -161,7 +168,8 @@ class FlarePortraitMode extends StatelessWidget {
                     : Container(),
                 RaisedButton(
                   color: buttonOkColor ?? Colors.green,
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(buttonRadius)),
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(buttonRadius)),
                   onPressed: onOkButtonPressed ?? () {},
                   child: buttonOkText ??
                       Text(
@@ -226,7 +234,9 @@ class FlareLandscapeMode extends StatelessWidget {
               elevation: 0.0,
               margin: EdgeInsets.all(0.0),
               shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.only(topLeft: Radius.circular(cornerRadius), bottomLeft: Radius.circular(cornerRadius))),
+                  borderRadius: BorderRadius.only(
+                      topLeft: Radius.circular(cornerRadius),
+                      bottomLeft: Radius.circular(cornerRadius))),
               clipBehavior: Clip.antiAlias,
               child: FlareActor(
                 flarePath,
@@ -251,12 +261,16 @@ class FlareLandscapeMode extends StatelessWidget {
                 Padding(
                   padding: const EdgeInsets.all(8.0),
                   child: Row(
-                    mainAxisAlignment: !onlyOkButton ? MainAxisAlignment.spaceEvenly : MainAxisAlignment.center,
+                    mainAxisAlignment: !onlyOkButton
+                        ? MainAxisAlignment.spaceEvenly
+                        : MainAxisAlignment.center,
                     children: <Widget>[
                       !onlyOkButton
                           ? RaisedButton(
                               color: buttonCancelColor ?? Colors.grey,
-                              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(buttonRadius)),
+                              shape: RoundedRectangleBorder(
+                                  borderRadius:
+                                      BorderRadius.circular(buttonRadius)),
                               onPressed: () => Navigator.of(context).pop(),
                               child: buttonCancelText ??
                                   Text(
@@ -267,7 +281,8 @@ class FlareLandscapeMode extends StatelessWidget {
                           : Container(),
                       RaisedButton(
                         color: buttonOkColor ?? Colors.green,
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(buttonRadius)),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(buttonRadius)),
                         onPressed: onOkButtonPressed ?? () {},
                         child: buttonOkText ??
                             Text(

--- a/test/giffy_dialog_test.dart
+++ b/test/giffy_dialog_test.dart
@@ -1,11 +1,21 @@
-import 'package:flutter/services.dart';
+import 'dart:ui';
+
 import 'package:flutter_test/flutter_test.dart';
 import '../example/lib/main.dart';
 import 'package:image_test_utils/image_test_utils.dart';
 
+const double PORTRAIT_WIDTH = 600.0;
+const double PORTRAIT_HEIGHT = 800.0;
+const double LANDSCAPE_WIDTH = 800.0;
+const double LANDSCAPE_HEIGHT = 600.0;
+
 void main() {
   testWidgets('Check Portrait Dialog test', (WidgetTester tester) async {
     provideMockedNetworkImages(() async {
+      final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+      await binding.setSurfaceSize(Size(PORTRAIT_WIDTH, PORTRAIT_HEIGHT));
+
       // Build our app and trigger a frame.
       await tester.pumpWidget(new MyApp());
 
@@ -40,13 +50,12 @@ void main() {
 
   testWidgets('Check Landscape Dialog test', (WidgetTester tester) async {
     provideMockedNetworkImages(() async {
+      final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+      await binding.setSurfaceSize(Size(LANDSCAPE_WIDTH, LANDSCAPE_HEIGHT));
+
       // Build our app and trigger a frame.
       await tester.pumpWidget(new MyApp());
-
-      SystemChrome.setPreferredOrientations([
-        DeviceOrientation.landscapeRight,
-        DeviceOrientation.landscapeLeft,
-      ]);
 
       expect(find.byKey(keys[0]), findsOneWidget);
 

--- a/test/giffy_dialog_test.dart
+++ b/test/giffy_dialog_test.dart
@@ -1,12 +1,52 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../example/lib/main.dart';
 import 'package:image_test_utils/image_test_utils.dart';
 
 void main() {
-  testWidgets('Check button smoke test', (WidgetTester tester) async {
+  testWidgets('Check Portrait Dialog test', (WidgetTester tester) async {
     provideMockedNetworkImages(() async {
       // Build our app and trigger a frame.
       await tester.pumpWidget(new MyApp());
+
+      expect(find.byKey(keys[0]), findsOneWidget);
+
+      await tester.tap(find.byKey(keys[0]));
+      await tester.pump();
+
+      expect(find.byKey(keys[1]), findsOneWidget);
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pump();
+
+      expect(find.byKey(keys[2]), findsOneWidget);
+
+      await tester.tap(find.byKey(keys[2]));
+      await tester.pump();
+
+      expect(find.byKey(keys[3]), findsOneWidget);
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pump();
+
+      expect(find.byKey(keys[4]), findsOneWidget);
+
+      await tester.tap(find.byKey(keys[4]));
+      await tester.pump();
+
+      expect(find.byKey(keys[5]), findsOneWidget);
+    });
+  });
+
+  testWidgets('Check Landscape Dialog test', (WidgetTester tester) async {
+    provideMockedNetworkImages(() async {
+      // Build our app and trigger a frame.
+      await tester.pumpWidget(new MyApp());
+
+      SystemChrome.setPreferredOrientations([
+        DeviceOrientation.landscapeRight,
+        DeviceOrientation.landscapeLeft,
+      ]);
 
       expect(find.byKey(keys[0]), findsOneWidget);
 

--- a/test/giffy_dialog_test.dart
+++ b/test/giffy_dialog_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:giffy_dialog/giffy_dialog.dart';
 import '../example/lib/main.dart';
 import 'package:image_test_utils/image_test_utils.dart';
 
@@ -10,79 +11,126 @@ const double LANDSCAPE_WIDTH = 800.0;
 const double LANDSCAPE_HEIGHT = 600.0;
 
 void main() {
-  testWidgets('Check Portrait Dialog test', (WidgetTester tester) async {
-    provideMockedNetworkImages(() async {
-      final TestWidgetsFlutterBinding binding =
-      TestWidgetsFlutterBinding.ensureInitialized();
-      await binding.setSurfaceSize(Size(PORTRAIT_WIDTH, PORTRAIT_HEIGHT));
+  group('Dialog Assertion Test', () {
+    testWidgets(
+        'AssetGiffyDialog throws if initialized with null image and title',
+        (WidgetTester tester) async {
+      try {
+        await tester.pumpWidget(AssetGiffyDialog(
+          onOkButtonPressed: () {},
+          image: null,
+          title: null,
+        ));
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
+    });
 
-      // Build our app and trigger a frame.
-      await tester.pumpWidget(new MyApp());
+    testWidgets(
+        'FlareGiffyDialog throws if initialized with null flarePath, flareAnimation and title',
+        (WidgetTester tester) async {
+      try {
+        await tester.pumpWidget(FlareGiffyDialog(
+          onOkButtonPressed: () {},
+          flarePath: null,
+          title: null,
+          flareAnimation: null,
+        ));
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
+    });
 
-      expect(find.byKey(keys[0]), findsOneWidget);
-
-      await tester.tap(find.byKey(keys[0]));
-      await tester.pump();
-
-      expect(find.byKey(keys[1]), findsOneWidget);
-
-      await tester.tap(find.text('Cancel'));
-      await tester.pump();
-
-      expect(find.byKey(keys[2]), findsOneWidget);
-
-      await tester.tap(find.byKey(keys[2]));
-      await tester.pump();
-
-      expect(find.byKey(keys[3]), findsOneWidget);
-
-      await tester.tap(find.text('Cancel'));
-      await tester.pump();
-
-      expect(find.byKey(keys[4]), findsOneWidget);
-
-      await tester.tap(find.byKey(keys[4]));
-      await tester.pump();
-
-      expect(find.byKey(keys[5]), findsOneWidget);
+    testWidgets(
+        'NetworkGiffyDialog throws if initialized with null image and title',
+        (WidgetTester tester) async {
+      try {
+        await tester.pumpWidget(NetworkGiffyDialog(
+          onOkButtonPressed: () {},
+          image: null,
+          title: null,
+        ));
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
     });
   });
 
-  testWidgets('Check Landscape Dialog test', (WidgetTester tester) async {
-    provideMockedNetworkImages(() async {
-      final TestWidgetsFlutterBinding binding =
-      TestWidgetsFlutterBinding.ensureInitialized();
-      await binding.setSurfaceSize(Size(LANDSCAPE_WIDTH, LANDSCAPE_HEIGHT));
+  group('Dialog Smoke and Orientation Test', () {
+    testWidgets('Check Portrait Dialog test', (WidgetTester tester) async {
+      provideMockedNetworkImages(() async {
+        final TestWidgetsFlutterBinding binding =
+            TestWidgetsFlutterBinding.ensureInitialized();
+        await binding.setSurfaceSize(Size(PORTRAIT_WIDTH, PORTRAIT_HEIGHT));
 
-      // Build our app and trigger a frame.
-      await tester.pumpWidget(new MyApp());
+        // Build our app and trigger a frame.
+        await tester.pumpWidget(new MyApp());
 
-      expect(find.byKey(keys[0]), findsOneWidget);
+        expect(find.byKey(keys[0]), findsOneWidget);
 
-      await tester.tap(find.byKey(keys[0]));
-      await tester.pump();
+        await tester.tap(find.byKey(keys[0]));
+        await tester.pump();
 
-      expect(find.byKey(keys[1]), findsOneWidget);
+        expect(find.byKey(keys[1]), findsOneWidget);
 
-      await tester.tap(find.text('Cancel'));
-      await tester.pump();
+        await tester.tap(find.text('Cancel'));
+        await tester.pump();
 
-      expect(find.byKey(keys[2]), findsOneWidget);
+        expect(find.byKey(keys[2]), findsOneWidget);
 
-      await tester.tap(find.byKey(keys[2]));
-      await tester.pump();
+        await tester.tap(find.byKey(keys[2]));
+        await tester.pump();
 
-      expect(find.byKey(keys[3]), findsOneWidget);
+        expect(find.byKey(keys[3]), findsOneWidget);
 
-      await tester.tap(find.text('Cancel'));
-      await tester.pump();
+        await tester.tap(find.text('Cancel'));
+        await tester.pump();
 
-      expect(find.byKey(keys[4]), findsOneWidget);
+        expect(find.byKey(keys[4]), findsOneWidget);
 
-      await tester.tap(find.byKey(keys[4]));
-      await tester.pump();
+        await tester.tap(find.byKey(keys[4]));
+        await tester.pump();
 
-      expect(find.byKey(keys[5]), findsOneWidget);
+        expect(find.byKey(keys[5]), findsOneWidget);
+      });
+    });
+
+    testWidgets('Check Landscape Dialog test', (WidgetTester tester) async {
+      provideMockedNetworkImages(() async {
+        final TestWidgetsFlutterBinding binding =
+            TestWidgetsFlutterBinding.ensureInitialized();
+        await binding.setSurfaceSize(Size(LANDSCAPE_WIDTH, LANDSCAPE_HEIGHT));
+
+        // Build our app and trigger a frame.
+        await tester.pumpWidget(new MyApp());
+
+        expect(find.byKey(keys[0]), findsOneWidget);
+
+        await tester.tap(find.byKey(keys[0]));
+        await tester.pump();
+
+        expect(find.byKey(keys[1]), findsOneWidget);
+
+        await tester.tap(find.text('Cancel'));
+        await tester.pump();
+
+        expect(find.byKey(keys[2]), findsOneWidget);
+
+        await tester.tap(find.byKey(keys[2]));
+        await tester.pump();
+
+        expect(find.byKey(keys[3]), findsOneWidget);
+
+        await tester.tap(find.text('Cancel'));
+        await tester.pump();
+
+        expect(find.byKey(keys[4]), findsOneWidget);
+
+        await tester.tap(find.byKey(keys[4]));
+        await tester.pump();
+
+        expect(find.byKey(keys[5]), findsOneWidget);
+      });
     });
   });
 }

--- a/test/giffy_dialog_test.dart
+++ b/test/giffy_dialog_test.dart
@@ -5,63 +5,64 @@ import 'package:giffy_dialog/giffy_dialog.dart';
 import '../example/lib/main.dart';
 import 'package:image_test_utils/image_test_utils.dart';
 
-const double PORTRAIT_WIDTH = 600.0;
-const double PORTRAIT_HEIGHT = 800.0;
-const double LANDSCAPE_WIDTH = 800.0;
-const double LANDSCAPE_HEIGHT = 600.0;
+const double PORTRAIT_WIDTH = 1800.0;
+const double PORTRAIT_HEIGHT = 2400.0;
+const double LANDSCAPE_WIDTH = 2400.0;
+const double LANDSCAPE_HEIGHT = 1800.0;
 
 void main() {
   group('Dialog Assertion Test', () {
     testWidgets(
         'AssetGiffyDialog throws if initialized with null image and title',
-        (WidgetTester tester) async {
-      try {
-        await tester.pumpWidget(AssetGiffyDialog(
-          onOkButtonPressed: () {},
-          image: null,
-          title: null,
-        ));
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
+            (WidgetTester tester) async {
+          try {
+            await tester.pumpWidget(AssetGiffyDialog(
+              onOkButtonPressed: () {},
+              image: null,
+              title: null,
+            ));
+          } catch (error) {
+            expect(error, isAssertionError);
+          }
+        });
 
     testWidgets(
         'FlareGiffyDialog throws if initialized with null flarePath, flareAnimation and title',
-        (WidgetTester tester) async {
-      try {
-        await tester.pumpWidget(FlareGiffyDialog(
-          onOkButtonPressed: () {},
-          flarePath: null,
-          title: null,
-          flareAnimation: null,
-        ));
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
+            (WidgetTester tester) async {
+          try {
+            await tester.pumpWidget(FlareGiffyDialog(
+              onOkButtonPressed: () {},
+              flarePath: null,
+              title: null,
+              flareAnimation: null,
+            ));
+          } catch (error) {
+            expect(error, isAssertionError);
+          }
+        });
 
     testWidgets(
         'NetworkGiffyDialog throws if initialized with null image and title',
-        (WidgetTester tester) async {
-      try {
-        await tester.pumpWidget(NetworkGiffyDialog(
-          onOkButtonPressed: () {},
-          image: null,
-          title: null,
-        ));
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
+            (WidgetTester tester) async {
+          try {
+            await tester.pumpWidget(NetworkGiffyDialog(
+              onOkButtonPressed: () {},
+              image: null,
+              title: null,
+            ));
+          } catch (error) {
+            expect(error, isAssertionError);
+          }
+        });
   });
 
   group('Dialog Smoke and Orientation Test', () {
     testWidgets('Check Portrait Dialog test', (WidgetTester tester) async {
       provideMockedNetworkImages(() async {
         final TestWidgetsFlutterBinding binding =
-            TestWidgetsFlutterBinding.ensureInitialized();
-        await binding.setSurfaceSize(Size(PORTRAIT_WIDTH, PORTRAIT_HEIGHT));
+        TestWidgetsFlutterBinding.ensureInitialized();
+        binding.window.physicalSizeTestValue =
+        (Size(PORTRAIT_WIDTH, PORTRAIT_HEIGHT));
 
         // Build our app and trigger a frame.
         await tester.pumpWidget(new MyApp());
@@ -98,8 +99,9 @@ void main() {
     testWidgets('Check Landscape Dialog test', (WidgetTester tester) async {
       provideMockedNetworkImages(() async {
         final TestWidgetsFlutterBinding binding =
-            TestWidgetsFlutterBinding.ensureInitialized();
-        await binding.setSurfaceSize(Size(LANDSCAPE_WIDTH, LANDSCAPE_HEIGHT));
+        TestWidgetsFlutterBinding.ensureInitialized();
+        binding.window.physicalSizeTestValue =
+            Size(LANDSCAPE_WIDTH, LANDSCAPE_HEIGHT);
 
         // Build our app and trigger a frame.
         await tester.pumpWidget(new MyApp());


### PR DESCRIPTION
Fix #28 
- [x] - NetworkGiffyDialog test (Portrait mode)
- [x] - AssetGiffyDialog test (Portrait mode)
- [x] - FlareGiffyDialog test (Portrait mode)
- [x] - Test for covering all the possible assertions.