### PR TITLE
AssetGiffyDialog() widget doesn't have any property named 'imagePath'

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ onPressed: () {
 onPressed: () {
   showDialog(
   context: context,builder: (_) => AssetGiffyDialog(
-    imagePath: 'assets/men_wearing_jacket.gif',
+    image: Image.asset(
+              'assets/help_stick.gif',
+              fit: BoxFit.cover
+            ),,
     title: Text('Men Wearing Jackets',
             style: TextStyle(
             fontSize: 22.0, fontWeight: FontWeight.w600),

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ onPressed: () {
     image: Image.asset(
               'assets/help_stick.gif',
               fit: BoxFit.cover
-            ),,
+            ),
     title: Text('Men Wearing Jackets',
             style: TextStyle(
             fontSize: 22.0, fontWeight: FontWeight.w600),


### PR DESCRIPTION
The AssetGiffyDialog() widget doesn't take any 'imagePath' property. It rather takes the property with the name 'image'
and then the image can be passed using Image.asset()

It was not updated in the README.