### PR TITLE
fix: replaced deprecated `RaisedButton` with `ElevatedButton`

### DIFF
--- a/lib/src/base_dialog.dart
+++ b/lib/src/base_dialog.dart
@@ -200,24 +200,25 @@ class _BaseGiffyDialogState extends State<BaseGiffyDialog>
             : MainAxisAlignment.center,
         children: <Widget>[
           if (!widget.onlyOkButton) ...[
-            RaisedButton(
-              color: widget.buttonCancelColor,
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(widget.buttonRadius)),
-              onPressed: widget.onCancelButtonPressed ??
-                  () => Navigator.of(context).pop(),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: widget.buttonCancelColor,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(widget.buttonRadius)),
+              ),
+              onPressed: widget.onCancelButtonPressed ?? () => Navigator.of(context).pop(),
               child: widget.buttonCancelText ??
                   Text(
                     'Cancel',
                     style: TextStyle(color: Colors.white),
                   ),
-            )
+            ),
           ],
           if (!widget.onlyCancelButton) ...[
-            RaisedButton(
-              color: widget.buttonOkColor,
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(widget.buttonRadius)),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: widget.buttonOkColor,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(widget.buttonRadius)),
+              ),
               onPressed: widget.onOkButtonPressed,
               child: widget.buttonOkText ??
                   Text(


### PR DESCRIPTION
Material You (Material Design v3) has [deprecated `RaisedButton` in favour of `ElevatedButton`](https://docs.flutter.dev/release/breaking-changes/buttons#context)

Re-implement depreacted `RaisedButton` with `ElevatedButton`

- fixes #83 